### PR TITLE
fix(gatsby-browser): add replaceHydrateFunction to fix some styles not loaded on refresh

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,11 +1,18 @@
-import React from 'react';
-import { CookiesProvider  } from 'react-cookie';
-import { ThemeProvider } from './src/styles/themeContext';
+import React from "react"
+import ReactDOM from "react-dom"
+import { CookiesProvider } from "react-cookie"
+import { ThemeProvider } from "./src/styles/themeContext"
 
 export const wrapRootElement = ({ element }) => (
   <CookiesProvider>
-    <ThemeProvider>
-      {element}
-    </ThemeProvider>
+    <ThemeProvider>{element}</ThemeProvider>
   </CookiesProvider>
-);
+)
+
+// this is a hack to fix missing styles on refresh in production
+// reference: https://github.com/gatsbyjs/gatsby/issues/17676#issuecomment-535796737
+export const replaceHydrateFunction = () => {
+  return (element, container, callback) => {
+    ReactDOM.render(element, container, callback)
+  }
+}


### PR DESCRIPTION
## Test

The default theme is light. Try changing theme to dark and refresh the page. If navbar is loaded as dark theme correctly, the issue is solved.